### PR TITLE
Minji week2 hw

### DIFF
--- a/src/components/features/RoutineItem.jsx
+++ b/src/components/features/RoutineItem.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import CheckIcon from '../ui/CheckIcon';
+
+const RoutineItem = ({ name, days, completed, onToggle, remainingTime }) => (
+  <div
+    onClick={onToggle}
+    className={`p-4 rounded-lg shadow-sm flex items-center justify-between cursor-pointer transition-colors duration-300 ${
+      completed ? 'bg-blue-50' : 'bg-white'
+    }`}
+  >
+    <div>
+      <div className="flex items-center space-x-3">
+        <h3
+          className={`font-semibold transition-colors duration-300 ${
+            completed ? 'text-blue-500' : 'text-gray-800'
+          }`}
+        >
+          {name}
+        </h3>
+        {!completed && <span className="text-xs text-gray-400">{remainingTime}</span>}
+      </div>
+      <div className="flex space-x-1 mt-2">
+        {days.map((day) => (
+          <span
+            key={day}
+            className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full"
+          >
+            {day}
+          </span>
+        ))}
+      </div>
+    </div>
+    <CheckIcon completed={completed} />
+  </div>
+);
+
+export default RoutineItem;
+

--- a/src/hooks/useTime.jsx
+++ b/src/hooks/useTime.jsx
@@ -1,0 +1,31 @@
+
+import { useState, useEffect } from 'react';
+
+const useTime = () => {
+  const [currentTime, setCurrentTime] = useState(new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCurrentTime(new Date());
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  const getRemainingTime = () => {
+    const now = currentTime;
+    const midnight = new Date(now);
+    midnight.setHours(24, 0, 0, 0);
+
+    const diff = midnight.getTime() - now.getTime();
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+    const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  };
+
+  return { getRemainingTime };
+};
+
+export default useTime;

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import Header from '../components/layouts/Header';
+import BottomNav from '../components/layouts/BottomNav';
+import RoutineItem from '../components/features/RoutineItem';
+import FloatingActionButton from '../components/features/FloatingActionButton';
+import AddRoutineModal from '../components/features/AddRoutineModal';
+import useTime from '../hooks/useTime';
+
+const MainPage = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { getRemainingTime } = useTime();
+  const [routines, setRoutines] = useState([
+    { name: '물 마시기', days: ['월', '화', '수', '목', '금', '토', '일'], completed: true },
+    { name: '독서 30분', days: ['월', '수', '금'], completed: true },
+    { name: '운동하기', days: ['월', '화', '수', '목', '금'], completed: false },
+    { name: '일기 쓰기', days: ['월', '화', '수', '목', '금', '토', '일'], completed: false },
+  ]);
+
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  const addRoutine = (newRoutine) => {
+    setRoutines([...routines, { ...newRoutine, completed: false }]);
+  };
+
+  const toggleRoutine = (index) => {
+    const newRoutines = [...routines];
+    newRoutines[index].completed = !newRoutines[index].completed;
+    setRoutines(newRoutines);
+  };
+
+  const achievement = routines.length > 0 ? (routines.filter(r => r.completed).length / routines.length) * 100 : 0;
+
+  return (
+    <div className="bg-gray-50 min-h-screen font-sans">
+      <Header />
+      <main className="p-6">
+        <div className="max-w-md mx-auto">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-xl font-semibold text-gray-800">오늘의 루틴</h2>
+            <span className="text-sm text-gray-500">10월 3일 금요일</span>
+          </div>
+
+          <div className="bg-white p-4 rounded-lg shadow-sm mb-6">
+            <div className="flex justify-between items-center mb-2">
+              <span className="text-sm font-medium text-gray-600">오늘의 달성률</span>
+              <span className="text-lg font-bold text-blue-500">{achievement.toFixed(0)}%</span>
+            </div>
+            <div className="w-full bg-gray-200 rounded-full h-2">
+              <div className="bg-blue-500 h-2 rounded-full transition-all duration-300" style={{ width: `${achievement}%` }}></div>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {routines.map((routine, index) => (
+              <RoutineItem
+                key={index}
+                {...routine}
+                remainingTime={getRemainingTime()}
+                onToggle={() => toggleRoutine(index)}
+              />
+            ))}
+          </div>
+        </div>
+      </main>
+      <FloatingActionButton onClick={openModal} />
+      <BottomNav />
+      <AddRoutineModal isOpen={isModalOpen} onClose={closeModal} onAdd={addRoutine} />
+    </div>
+  );
+};
+
+export default MainPage;


### PR DESCRIPTION
## 구현 포인트

- 루틴 완료까지 남은 시간을 표시하는 기능을 추가했습니다.
- `useTime` 커스텀 훅을 사용하여 시간 관련 로직을 분리했습니다.

## 활용한 MCP
- time-mcp: 루틴 트래킹까지 남은 시간 표시
- google workspace: Google Calendar에 루틴 이벤트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  - 오늘의 루틴을 한눈에 관리할 수 있는 메인 화면을 추가했습니다. 목록과 함께 달성률(%)과 진행 바로 하루 진척도를 확인할 수 있습니다. 플로팅 버튼과 추가 모달로 새 루틴을 손쉽게 생성하고, 각 항목은 클릭으로 완료 상태를 전환할 수 있습니다. 요일 배지와 완료 아이콘으로 상태가 명확하며, 미완료 루틴에는 자정까지 남은 시간이 실시간으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->